### PR TITLE
refactor: disallow kwargs for `Flag` subclasses

### DIFF
--- a/discatpy/bot.py
+++ b/discatpy/bot.py
@@ -15,6 +15,31 @@ __all__ = ("Intents", "Bot")
 
 
 class Intents(Flag):
+    if t.TYPE_CHECKING:
+        def __init__(
+            self,
+            guilds: bool = ...,
+            guild_members: bool = ...,
+            guild_bans: bool = ...,
+            guild_emojis_and_stickers: bool = ...,
+            guild_integrations: bool = ...,
+            guild_webhooks: bool = ...,
+            guild_invites: bool = ...,
+            guild_voice_states: bool = ...,
+            guild_presences: bool = ...,
+            guild_messages: bool = ...,
+            guild_message_reactions: bool = ...,
+            guild_message_typing: bool = ...,
+            direct_messages: bool = ...,
+            direct_message_reactions: bool = ...,
+            direct_message_typing: bool = ...,
+            message_content: bool = ...,
+            guild_scheduled_events: bool = ...,
+            auto_moderation_configuration: bool = ...,
+            automod_execution: bool = ...,
+        ) -> None:
+            ...
+
     @flag
     def GUILDS():
         return 1 << 0

--- a/discatpy/bot.py
+++ b/discatpy/bot.py
@@ -18,6 +18,7 @@ class Intents(Flag):
     if t.TYPE_CHECKING:
         def __init__(
             self,
+            *,
             guilds: bool = ...,
             guild_members: bool = ...,
             guild_bans: bool = ...,

--- a/discatpy/bot.py
+++ b/discatpy/bot.py
@@ -16,6 +16,7 @@ __all__ = ("Intents", "Bot")
 
 class Intents(Flag):
     if t.TYPE_CHECKING:
+
         def __init__(
             self,
             *,

--- a/discatpy/models/message.py
+++ b/discatpy/models/message.py
@@ -110,6 +110,7 @@ class MessageTypes(int, Enum):
 
 class MessageFlags(Flag):
     if t.TYPE_CHECKING:
+
         def __init__(
             self,
             *,
@@ -124,6 +125,7 @@ class MessageFlags(Flag):
             failed_to_mention_some_roles_in_thread: bool = ...,
         ):
             ...
+
     @flag
     def CROSSPOSTED():
         return 1 << 0

--- a/discatpy/models/message.py
+++ b/discatpy/models/message.py
@@ -109,6 +109,20 @@ class MessageTypes(int, Enum):
 
 
 class MessageFlags(Flag):
+    if t.TYPE_CHECKING:
+        def __init__(
+            self,
+            crossposted: bool = ...,
+            is_crosspost: bool = ...,
+            suppress_embeds: bool = ...,
+            source_message_deleted: bool = ...,
+            urgent: bool = ...,
+            has_thread: bool = ...,
+            ephemeral: bool = ...,
+            loading: bool = ...,
+            failed_to_mention_some_roles_in_thread: bool = ...,
+        ):
+            ...
     @flag
     def CROSSPOSTED():
         return 1 << 0

--- a/discatpy/models/message.py
+++ b/discatpy/models/message.py
@@ -112,6 +112,7 @@ class MessageFlags(Flag):
     if t.TYPE_CHECKING:
         def __init__(
             self,
+            *,
             crossposted: bool = ...,
             is_crosspost: bool = ...,
             suppress_embeds: bool = ...,

--- a/discatpy/models/permissions.py
+++ b/discatpy/models/permissions.py
@@ -11,6 +11,7 @@ class Permissions(Flag):
     if t.TYPE_CHECKING:
         def __init__(
             self,
+            *,
             create_instant_invite: bool = ...,
             kick_members: bool = ...,
             ban_members: bool = ...,

--- a/discatpy/models/permissions.py
+++ b/discatpy/models/permissions.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-
+import typing as t
 from typing_extensions import Self
 
 from ..flags import Flag, flag
@@ -8,6 +8,51 @@ __all__ = ("Permissions", "PermissionOverwrite")
 
 
 class Permissions(Flag):
+    if t.TYPE_CHECKING:
+        def __init__(
+            self,
+            create_instant_invite: bool = ...,
+            kick_members: bool = ...,
+            ban_members: bool = ...,
+            administrator: bool = ...,
+            manage_channels: bool = ...,
+            manage_guild: bool = ...,
+            add_reactions: bool = ...,
+            view_audit_log: bool = ...,
+            priority_speaker: bool = ...,
+            stream: bool = ...,
+            view_channel: bool = ...,
+            send_messages: bool = ...,
+            send_tts_messages: bool = ...,
+            manage_messages: bool = ...,
+            embed_links: bool = ...,
+            attach_files: bool = ...,
+            read_message_history: bool = ...,
+            mention_everyone: bool = ...,
+            use_external_emojis: bool = ...,
+            view_guild_insights: bool = ...,
+            connect: bool = ...,
+            speak: bool = ...,
+            mute_members: bool = ...,
+            deafen_members: bool = ...,
+            move_members: bool = ...,
+            use_vad: bool = ...,
+            change_nickname: bool = ...,
+            manage_nicknames: bool = ...,
+            manage_roles: bool = ...,
+            manage_webhooks: bool = ...,
+            manage_emojis_and_stickers: bool = ...,
+            use_application_commands: bool = ...,
+            request_to_speak: bool = ...,
+            manage_threads: bool = ...,
+            create_public_threads: bool = ...,
+            create_private_threads: bool = ...,
+            use_external_stickers: bool = ...,
+            send_messages_in_threads: bool = ...,
+            use_embed_activities: bool = ...,
+            moderate_members: bool = ...
+        ) -> None:
+            ...
     @flag
     def create_instant_invite() -> int:
         return 1 << 0

--- a/discatpy/models/permissions.py
+++ b/discatpy/models/permissions.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 import typing as t
+
 from typing_extensions import Self
 
 from ..flags import Flag, flag
@@ -9,6 +10,7 @@ __all__ = ("Permissions", "PermissionOverwrite")
 
 class Permissions(Flag):
     if t.TYPE_CHECKING:
+
         def __init__(
             self,
             *,
@@ -51,9 +53,10 @@ class Permissions(Flag):
             use_external_stickers: bool = ...,
             send_messages_in_threads: bool = ...,
             use_embed_activities: bool = ...,
-            moderate_members: bool = ...
+            moderate_members: bool = ...,
         ) -> None:
             ...
+
     @flag
     def create_instant_invite() -> int:
         return 1 << 0

--- a/discatpy/models/user.py
+++ b/discatpy/models/user.py
@@ -33,6 +33,7 @@ class UserFlags(Flag):
     if t.TYPE_CHECKING:
         def __init__(
             self,
+            *,
             staff: bool = ...,
             partner: bool = ...,
             hypesquad: bool = ...,

--- a/discatpy/models/user.py
+++ b/discatpy/models/user.py
@@ -31,6 +31,7 @@ class UserPremiumTypes(int, Enum):
 
 class UserFlags(Flag):
     if t.TYPE_CHECKING:
+
         def __init__(
             self,
             *,
@@ -51,6 +52,7 @@ class UserFlags(Flag):
             active_developer: bool = ...,
         ) -> None:
             ...
+
     @flag
     def STAFF():
         return 1 << 0

--- a/discatpy/models/user.py
+++ b/discatpy/models/user.py
@@ -30,6 +30,26 @@ class UserPremiumTypes(int, Enum):
 
 
 class UserFlags(Flag):
+    if t.TYPE_CHECKING:
+        def __init__(
+            self,
+            staff: bool = ...,
+            partner: bool = ...,
+            hypesquad: bool = ...,
+            bug_hunter_level_1: bool = ...,
+            hypesquad_online_house_1: bool = ...,
+            hypesquad_online_house_2: bool = ...,
+            hypesquad_online_house_3: bool = ...,
+            premium_early_supporter: bool = ...,
+            team_pseudo_user: bool = ...,
+            bug_hunter_level_2: bool = ...,
+            verified_bot: bool = ...,
+            early_verified_bot_developer: bool = ...,
+            certified_moderator: bool = ...,
+            bot_http_interactions: bool = ...,
+            active_developer: bool = ...,
+        ) -> None:
+            ...
     @flag
     def STAFF():
         return 1 << 0


### PR DESCRIPTION
This pull request explicitly types parameters in `Flag` subclasses such as UserFlags, Permissions, Intents, and MessageFlags.

This has not been fully tested; It does not look like any problem can occur with this, however better safe than sorry.