### PR TITLE
refactor(PermissionOverwrite): disallow kwargs

### DIFF
--- a/discatpy/models/permissions.py
+++ b/discatpy/models/permissions.py
@@ -305,5 +305,58 @@ class PermissionOverwrite:
 
         return cls(**permissions_kwargs)
 
+    @t.overload
+    def set(
+        self,
+    ) -> None:
+        ...
+
+    @t.overload
+    def set(
+        self,
+        *,
+        create_instant_invite: bool = ...,
+        kick_members: bool = ...,
+        ban_members: bool = ...,
+        administrator: bool = ...,
+        manage_channels: bool = ...,
+        manage_guild: bool = ...,
+        add_reactions: bool = ...,
+        view_audit_log: bool = ...,
+        priority_speaker: bool = ...,
+        stream: bool = ...,
+        view_channel: bool = ...,
+        send_messages: bool = ...,
+        send_tts_messages: bool = ...,
+        manage_messages: bool = ...,
+        embed_links: bool = ...,
+        attach_files: bool = ...,
+        read_message_history: bool = ...,
+        mention_everyone: bool = ...,
+        use_external_emojis: bool = ...,
+        view_guild_insights: bool = ...,
+        connect: bool = ...,
+        speak: bool = ...,
+        mute_members: bool = ...,
+        deafen_members: bool = ...,
+        move_members: bool = ...,
+        use_vad: bool = ...,
+        change_nickname: bool = ...,
+        manage_nicknames: bool = ...,
+        manage_roles: bool = ...,
+        manage_webhooks: bool = ...,
+        manage_emojis_and_stickers: bool = ...,
+        use_application_commands: bool = ...,
+        request_to_speak: bool = ...,
+        manage_threads: bool = ...,
+        create_public_threads: bool = ...,
+        create_private_threads: bool = ...,
+        use_external_stickers: bool = ...,
+        send_messages_in_threads: bool = ...,
+        use_embed_activities: bool = ...,
+        moderate_members: bool = ...,
+    ) -> None:
+        ...
+
     def set(self, **kwargs: bool):
         self._permission = Permissions(**kwargs)

--- a/discatpy/models/permissions.py
+++ b/discatpy/models/permissions.py
@@ -223,6 +223,59 @@ class Permissions(Flag):
 
 
 class PermissionOverwrite:
+    @t.overload
+    def __init__(
+        self,
+    ) -> None:
+        ...
+
+    @t.overload
+    def __init__(
+        self,
+        *,
+        create_instant_invite: bool = ...,
+        kick_members: bool = ...,
+        ban_members: bool = ...,
+        administrator: bool = ...,
+        manage_channels: bool = ...,
+        manage_guild: bool = ...,
+        add_reactions: bool = ...,
+        view_audit_log: bool = ...,
+        priority_speaker: bool = ...,
+        stream: bool = ...,
+        view_channel: bool = ...,
+        send_messages: bool = ...,
+        send_tts_messages: bool = ...,
+        manage_messages: bool = ...,
+        embed_links: bool = ...,
+        attach_files: bool = ...,
+        read_message_history: bool = ...,
+        mention_everyone: bool = ...,
+        use_external_emojis: bool = ...,
+        view_guild_insights: bool = ...,
+        connect: bool = ...,
+        speak: bool = ...,
+        mute_members: bool = ...,
+        deafen_members: bool = ...,
+        move_members: bool = ...,
+        use_vad: bool = ...,
+        change_nickname: bool = ...,
+        manage_nicknames: bool = ...,
+        manage_roles: bool = ...,
+        manage_webhooks: bool = ...,
+        manage_emojis_and_stickers: bool = ...,
+        use_application_commands: bool = ...,
+        request_to_speak: bool = ...,
+        manage_threads: bool = ...,
+        create_public_threads: bool = ...,
+        create_private_threads: bool = ...,
+        use_external_stickers: bool = ...,
+        send_messages_in_threads: bool = ...,
+        use_embed_activities: bool = ...,
+        moderate_members: bool = ...,
+    ) -> None:
+        ...
+
     def __init__(self, **kwargs: bool):
         self._permission: Permissions = Permissions(**kwargs)
 


### PR DESCRIPTION
This pull request is a lot similar to #18, but disallows kwargs in the `PermissionOverwrite` class.

Also has not been tested.